### PR TITLE
The url for hosting a workshop from your fork is not correct

### DIFF
--- a/workshops/create-workshop/workshop.md
+++ b/workshops/create-workshop/workshop.md
@@ -315,7 +315,7 @@ git push
 
 You should now be able to access your workshop using this url:
 
-`https://aka.ms/ws?src=gh:<your-github-username>/moaw/main/workshops/<your-workshop-name>`.
+`https://aka.ms/ws?src=gh:<your-github-username>/moaw/main/workshops/<your-workshop-name>/workshop.md`.
 
 This is also a convenient way to quickly host your workshop without having to wait for it to be published on the main website.
 

--- a/workshops/create-workshop/workshop.md
+++ b/workshops/create-workshop/workshop.md
@@ -283,7 +283,7 @@ npm start
 
 This will start a local development server on port 4200.
 
-You can then open [`http://localhost:4200/workshop/<your-workshop-name>`](http://localhost:4200/workshop/<your-workshop-name>) in your browser to preview your workshop.
+You can then open [`http://localhost:4200/workshop/<your-workshop-name>/`](http://localhost:4200/workshop/<your-workshop-name>/) in your browser to preview your workshop.
 
 
 #### Use MOAW CLI
@@ -315,7 +315,7 @@ git push
 
 You should now be able to access your workshop using this url:
 
-`https://aka.ms/ws?src=gh:<your-github-username>/moaw/main/workshops/<your-workshop-name>/workshop.md`.
+`https://aka.ms/ws?src=gh:<your-github-username>/moaw/main/workshops/<your-workshop-name>/`.
 
 This is also a convenient way to quickly host your workshop without having to wait for it to be published on the main website.
 


### PR DESCRIPTION
https://aka.ms/ws?src=gh:<your-github-username>/moaw/main/workshops/<your-workshop-name>

should be

https://aka.ms/ws?src=gh:<your-github-username>/moaw/main/workshops/<your-workshop-name>/workshop.md