### PR TITLE
Updates to Fabric RAG workshop to use latest Azure AI Search

### DIFF
--- a/workshops/fabric-e2e-rag/workshop.md
+++ b/workshops/fabric-e2e-rag/workshop.md
@@ -68,7 +68,7 @@ By leveraging the RAG (Retrieval-Augmented Generation) framework, you can create
 
 The architecture of such an application is as shown below:
 
-![Architecture diagram connecting Azure OpenAI with Azure AI search and Document Intelligence](assets/schema.png)
+![Architecture diagram connecting Azure OpenAI with Azure AI Search and Document Intelligence](assets/schema.png)
 
 To get an in-depth understanding of the RAG framework, refer to [this workshop](https://moaw.dev/workshop/gh:azure-samples/azure-openai-rag-workshop/base/docs/)
 
@@ -206,7 +206,7 @@ document_path = "Files/support.pdf"  # Path to the PDF document
 df = spark.read.format("binaryFile").load(document_path).limit(10).cache()
 ```
 
-This code will read the PDF document and create a Spark DataFrame named `df` with the contents of the PDFs. The DataFrame will have a schema that represents the structure of the PDF document, including its textual content.
+This code will read the PDF document and create a Spark DataFrame named `df` with the contents of the PDF. The DataFrame will have a schema that represents the structure of the PDF document, including its textual content.
 
 Next, we'll use the Azure AI Document Intelligence to read the PDF documents and extract the text from them.
 
@@ -220,8 +220,8 @@ from pyspark.sql.functions import col
 
 analyze_document = (
     AnalyzeDocument()
-    .setSubscriptionKey(ai_services_key)
     .setPrebuiltModelId("prebuilt-layout")
+    .setSubscriptionKey(ai_services_key)
     .setLocation(ai_services_location)
     .setImageBytesCol("content")
     .setOutputCol("result")
@@ -249,7 +249,7 @@ Now that we have the text content of the PDF documents, we can generate embeddin
 
 ![Diagram of flow from entire PDF file to chunks to embeddings](assets/chunking-vector.svg)
 
-This process begins by splitting the text into chunks, then for each of the chunks we generate embeddings using Azure OpenAI. These embeddings are then stored in Azure AI search.
+This process begins by splitting the text into chunks, then for each of the chunks we generate embeddings using Azure OpenAI. These embeddings are then stored in Azure AI Search.
 
 ## Text Chunking
 
@@ -324,7 +324,7 @@ For more detailed information on generating embeddings with Azure OpenAI, see: [
 
 [Azure AI Search](https://learn.microsoft.com/azure/search/search-what-is-azure-search?WT.mc_id=data-114676-jndemenge) is a powerful search engine that includes the ability to perform full text search, vector search, and hybrid search. For more examples of its vector search capabilities, see the [azure-search-vector-samples repository](https://github.com/Azure/azure-search-vector-samples/).
 
-Storing data in the Azure AI search involves two main steps:
+Storing data in Azure AI Search involves two main steps:
 
 1. **Creating the index:** The first step is to define the schema of the search index, which includes the properties of each field as well as any vector search strategies that will be used.
 
@@ -389,9 +389,9 @@ else:
 ```
 
 
-The next step is to upload the chunks to the newly created Azure AI search index. The [Azure AI Search REST API](https://learn.microsoft.com/rest/api/searchservice/addupdate-or-delete-documents) supports up to 1000 "documents" per request. Note that in this case, each of our "documents" is in fact a chunk of the original file.
+The next step is to upload the chunks to the newly created Azure AI Search index. The [Azure AI Search REST API](https://learn.microsoft.com/rest/api/searchservice/addupdate-or-delete-documents) supports up to 1000 "documents" per request. Note that in this case, each of our "documents" is in fact a chunk of the original file.
 
-In order to efficiently upload the chunks to the Azure AI search index, we'll use the `mapPartitions` function to process each partition of the dataframe. For each partition, the `upload_rows` function will collect 1000 rows at a time and upload them to the Azure AI search index. The function will then return the start and end index of the rows that were uploaded, as well as the status of the insertion, so that we know if the upload was successful or not.
+In order to efficiently upload the chunks to the Azure AI Search index, we'll use the `mapPartitions` function to process each partition of the dataframe. For each partition, the `upload_rows` function will collect 1000 rows at a time and upload them to the index. The function will then return the start and end index of the rows that were uploaded, as well as the status of the insertion, so that we know if the upload was successful or not.
 
 ```python
 from azure.search.documents import SearchClient
@@ -401,7 +401,7 @@ from pyspark.sql.functions import monotonically_increasing_id
 
 
 def insert_into_index(documents):
-    """Uploads a list of 'documents' to Azure AI search index."""
+    """Uploads a list of 'documents' to Azure AI Search index."""
 
     url = f"https://{aisearch_name}.search.windows.net/indexes/{aisearch_index_name}/docs/index?api-version=2023-11-01"
 
@@ -420,8 +420,8 @@ def insert_into_index(documents):
 
 
 def upload_rows(rows):
-    """Uploads the rows in a Spark dataframe to Azure AI search.
-    Limits uploads to 1000 rows at a time due to Azure AI search limits.
+    """Uploads the rows in a Spark dataframe to Azure AI Search.
+    Limits uploads to 1000 rows at a time due to Azure AI Search API limits.
     """
     BATCH_SIZE = 1000
     rows = list(rows)
@@ -453,7 +453,7 @@ display(res.toDF(["start_idx", "end_idx", "insertion_status"]))
 
 <div class="tip" data-title="Tip">
 
-> You can also use the [azure-search-documents Python package](https://pypi.org/project/azure-search-documents/) for Azure AI search operations.
+> You can also use the [azure-search-documents Python package](https://pypi.org/project/azure-search-documents/) for Azure AI Search operations.
 > You would first need to install that package into the Spark environment. See [Library management in Fabric environments](https://learn.microsoft.com/fabric/data-engineering/environment-manage-library)
 
 </div>
@@ -523,7 +523,7 @@ import json
 import requests
 
 def retrieve_top_chunks(k, question, question_embedding):
-    """Retrieve the top K entries from Azure AI search using hybrid search."""
+    """Retrieve the top K entries from Azure AI Search using hybrid search."""
     url = f"https://{aisearch_name}.search.windows.net/indexes/{aisearch_index_name}/docs/search?api-version=2023-11-01"
 
     payload = json.dumps({

--- a/workshops/fabric-e2e-rag/workshop.md
+++ b/workshops/fabric-e2e-rag/workshop.md
@@ -309,6 +309,17 @@ This integration enables the SynapseML embedding client to generate embeddings i
 
 For more detailed information on generating embeddings with Azure OpenAI, see: [Learn how to generate embeddings with Azure OpenAI](https://learn.microsoft.com/azure/cognitive-services/openai/how-to/embeddings?tabs=console&WT.mc_id=data-114676-jndemenge).
 
+<div class="info" data-title="Note">
+
+> If you're using the Azure OpenAI resource deployed on Microsoft Azure, you will need to provide the key as well as the deployment name for the Azure OpenAI resource, using `setDeploymentName` and `setSubscriptionKey`:
+>
+> ```python
+>     .setDeploymentName('YOUR-DEPLOYMENT_NAME')
+>     .setSubscriptionKey('YOUR-AZURE-OPENAI-KEY')
+> ```
+
+</div>
+
 ## Storing Embeddings
 
 [Azure AI Search](https://learn.microsoft.com/azure/search/search-what-is-azure-search?WT.mc_id=data-114676-jndemenge) is a powerful search engine that includes the ability to perform full text search, vector search, and hybrid search. For more examples of its vector search capabilities, see the [azure-search-vector-samples repository](https://github.com/Azure/azure-search-vector-samples/).

--- a/workshops/fabric-e2e-rag/workshop.md
+++ b/workshops/fabric-e2e-rag/workshop.md
@@ -110,11 +110,11 @@ Similarly, create another resource for the `Azure AI Services` by clicking on `C
 
 Fill out all the required fields, accept the Responsible AI Notice and then click `Review + Create` and once the validation is successful, click `Create`. Ensure that you select the same ***Resource Group*** as the ***Azure AI Search resource***.
 
-## Azure Open AI Set Up
+## Azure OpenAI Set Up
 
-If you are have an F64+ Capacity you can skip this step. 
+If your Microsoft Fabric SKU of F64 or higher, you can skip this step. 
 
-However if you are using are using the trial version of Microsoft Fabric or do not have an F64+ capacity, you will need to request access to the Azure OpenAI API from [here](https://aka.ms/oaiapply). Once you have access to the Azure OpenAI API, we'll need to create the Azure OpenAI resource in the Azure Portal.
+However, if you using the trial version of Microsoft Fabric or it does not have an F64+ SKU, you will need to request access to the Azure OpenAI API from [here](https://aka.ms/oaiapply). Once you have access to the Azure OpenAI API, you'll need to create the Azure OpenAI resource in the Azure Portal.
 
 To do this navigate to the [Azure Portal] and click on `Create a resource` and search for `Azure OpenAI`. Click on the `Azure OpenAI` resource and then click on `Create`. 
 
@@ -122,7 +122,7 @@ To do this navigate to the [Azure Portal] and click on `Create a resource` and s
 
 Fill out all the required fields and click `Review + Create` and once the validation is successful, click `Create`. Also ensure that you select the same ***Resource Group*** as the ***Azure AI Search resource*** and the ***Azure AI Services resource***.
 
-Next we'll need to create new model deployments. To do this navigate to the [Azure OpenAI Studio](https://oai.azure.com/portal). Under management click on `Deployments` and then click on `Create Deployment`. We'll need to create two deployments, one for the `text-embedding-ada-002` and another for the `gpt-35-turbo-16k`.
+Next you'll need to create new model deployments. To do this navigate to the [Azure OpenAI Studio](https://oai.azure.com/portal). Under management click on `Deployments` and then click on `Create Deployment`. You'll need to create two deployments, one for the `text-embedding-ada-002` model and another for the `gpt-35-turbo-16k` model.
 
 ![deployments](assets/deployments.png)
 
@@ -145,13 +145,12 @@ To do this, we'll perform the following steps:
 - Use SynapseML to split the documents into chunks for more granular representation and processing of the document content.
 
 ## Configure Azure API keys
-To begin with create a new notebook in your Lakehouse. To create a new Notebook, click on the ```Open Notebook``` from the Lakehouse and from the drop down menu select ```New Notebook```. 
 
-This will open a new Notebook. On the top right corner of the workspace click on the Notebook name and rename it to ```analyze_and_create_embeddings```. Click on any empty area to close and rename the Notebook.
+To begin, navigate back to your workspace and create a new notebook by selecting ```Open Notebook``` from the top menu and selecting ```New Notebook``` from the dropdown. 
 
-![new_notebook](assets/new_notebook.png)
+This will open a new Notebook. On the top right corner of the workspace, select the `Save as` icon and rename it to ```analyze_and_create_embeddings```.
 
-Next we'll need to provide the keys for Azure AI Services to access the services. Copy the values from the Azure Portal and paste them into the following code cell.
+Next you'll need to provide the keys for Azure AI Services to access the services. Copy the values from the Azure Portal and paste them into the following code cell.
 
 
 ```python
@@ -196,9 +195,9 @@ with open(os.path.join(path, 'support.pdf'), 'wb') as f:
     f.write(response.content)
 ```
 
-Thus downloads and stores the documents in the `Files` directory in the Lakehouse.
+This downloads and stores the document in the `Files` directory in the Lakehouse.
 
-Next we'll load the PDF document into a Spark DataFrame using the `spark.read.format("binaryFile")`method provided by Apache Spark.
+Next, load the PDF document into a Spark DataFrame using the `spark.read.format("binaryFile")` method provided by Apache Spark:
 
 ```python
 # Import required pyspark libraries
@@ -216,7 +215,7 @@ df = (
 )
 ```
 
-This code will read the PDF document and create a Spark DataFrame named `df` with the contents of the PDFs. The DataFrame will have a schema that represents the structure of the PDF documents, including their textual content.
+This code will read the PDF document and create a Spark DataFrame named `df` with the contents of the PDFs. The DataFrame will have a schema that represents the structure of the PDF document, including its textual content.
 
 Next, we'll use the Azure AI Document Intelligence to read the PDF documents and extract the text from them. 
 
@@ -315,24 +314,14 @@ display(df_embeddings)
 
 This integration enables the SynapseML embedding client to generate embeddings in a distributed manner, enabling efficient processing of large volumes of data. If you're interested in applying large language models at a distributed scale using Azure OpenAI and Azure Synapse Analytics, you can refer to [this approach](https://microsoft.github.io/SynapseML/docs/Explore%20Algorithms/OpenAI/). 
 
-For more detailed information on generating embeddings with Azure OpenAI, you can look [here]( https://learn.microsoft.com/azure/cognitive-services/openai/how-to/embeddings?tabs=console&WT.mc_id=data-114676-jndemenge).
+For more detailed information on generating embeddings with Azure OpenAI, you can look [here](https://learn.microsoft.com/azure/cognitive-services/openai/how-to/embeddings?tabs=console&WT.mc_id=data-114676-jndemenge).
 
-<div class="warning" data-title="Note">
-
-> If you are using the Azure OpenAI resource deployed on Microsoft Azure you will need to provide the Key as well as the Deployment Name for the Azure OpenAI resource. To do this replace the `deploymentName` with the name of the deployment you created in the Azure OpenAI Studio and add the key as follows:
-
-```python
-    .setDeploymentName('text-embedding-ada-002')
-    .setSubscriptionKey(azure_openai_key)
-```
-</div>
 
 ## Storing Embeddings in a Vector Store
 
-[Azure Cognitive Search](https://learn.microsoft.com/azure/search/search-what-is-azure-search?WT.mc_id=data-114676-jndemenge) offers a user-friendly interface for creating a vector database, as well as storing and retrieving data using vector search. If you're interested in learning more about vector search, you can look [here](https://github.com/Azure/cognitive-search-vector-pr/tree/main).
+[Azure AI Search](https://learn.microsoft.com/azure/search/search-what-is-azure-search?WT.mc_id=data-114676-jndemenge) offers a user-friendly interface for creating a vector database, as well as storing and retrieving data using vector search. If you're interested in learning more about vector search, you can look [here](https://github.com/Azure/cognitive-search-vector-pr/tree/main).
 
-
-Storing data in the AzureCogSearch vector database involves two main steps:
+Storing data in the Azure AI search involves two main steps:
 
 1. **Creating the Index:** The first step is to establish the index or schema of the vector database. This entails defining the structure and properties of the data that will be stored and indexed in the vector database.
 
@@ -346,7 +335,7 @@ import requests
 import json
 
 EMBEDDING_LENGTH = (
-    1536  # length of the embedding vector (OpenAI generates embeddings of length 1536)
+    1536  # length of the embedding vector (ada-002 generates embeddings of length 1536)
 )
 
 # Create Index for Cog Search with fields as id, content, and contentVector
@@ -392,15 +381,15 @@ response = requests.request("PUT", url, headers=headers, data=payload)
 print(response.status_code)
 ```
 
-Next we need to use User Defined Function (UDF) through the udf() method in order to apply functions directly to the DataFrame.
+Next we can use a Spark User Defined Function (UDF) to apply functions directly to the DataFrame. This allows us to run the code in a distributed fashion.
 
 ```python
-# Use Spark's UDF to insert entries to Cognitive Search
-# This allows to run the code in a distributed fashion
+from pyspark.sql.functions import udf
+from pyspark.sql.types import StringType 
 
 # Define a UDF using the @udf decorator
 @udf(returnType=StringType())
-def insert_to_cog_search(idx, content, contentVector):
+def insert_into_ai_search(idx, content, content_vector):
     url = f"https://{aisearch_name}.search.windows.net/indexes/{aisearch_index_name}/docs/index?api-version=2023-07-01-Preview"
 
     payload = json.dumps(
@@ -409,7 +398,7 @@ def insert_to_cog_search(idx, content, contentVector):
                 {
                     "id": str(idx),
                     "content": content,
-                    "contentVector": contentVector.tolist(),
+                    "contentVector": content_vector.tolist(),
                     "@search.action": "upload",
                 },
             ]
@@ -421,7 +410,6 @@ def insert_to_cog_search(idx, content, contentVector):
     }
 
     response = requests.request("POST", url, headers=headers, data=payload)
-    # response.text
 
     if response.status_code == 200 or response.status_code == 201:
         return "Success"
@@ -429,24 +417,26 @@ def insert_to_cog_search(idx, content, contentVector):
         return "Failure"
 ```
 
-Now we can use the UDF to insert the chunked documents and their embeddings into the vector database by applying the UDF to the Spark DataFrame. Note that UDF also helps to add new columns to the DataFrame.
+Now we can use the UDF to insert the chunked documents and their embeddings into the search index by applying the UDF to the Spark DataFrame.
 
 ```python
-# Apply the UDF on the different columns
 from pyspark.sql.functions import monotonically_increasing_id
 
+# Add a column with an id
 df_embeddings = df_embeddings.withColumn(
     "idx", monotonically_increasing_id()
-)  ## adding a column with id
+)
+
+# Run UDF and store results in new column
 df_embeddings = df_embeddings.withColumn(
-    "errorCogSearch",
-    insert_to_cog_search(
+    "insertion_status",
+    insert_into_ai_search(
         df_embeddings["idx"], df_embeddings["chunk"], df_embeddings["embeddings"]
     ),
 )
 
 # Show the transformed DataFrame
-df_embeddings.show()
+display(df_embeddings)
 ```
 
 ---
@@ -456,16 +446,20 @@ df_embeddings.show()
 After processing the document, we can proceed to pose a question. We will use [SynapseML](https://microsoft.github.io/SynapseML/docs/Explore%20Algorithms/OpenAI/Quickstart%20-%20OpenAI%20Embedding/) to convert the user's question into an embedding and then utilize cosine similarity to retrieve the top K document chunks that closely match the user's question. 
 
 ## Configure Environment & Azure API Keys
-To do this, let's create a new notebook in the Lakehouse and rename it to `rag_application`. We'll use this notebook to build the RAG application.
 
-Next we'll need to provide the keys for Azure AI Services to access the services. Copy the values from the Azure Portal and paste them into the following code cell.
+Create a new notebook in the Lakehouse and save it as `rag_application`. We'll use this notebook to build the RAG application.
+
+Next we'll need to provide the keys for Azure AI Services to access the services. You can copy the values from the previous notebook or from Azure Portal.
+
 ```python
 # Azure AI Search
 aisearch_name = ''
 aisearch_index_name = 'rag-demo-index'
 aisearch_api_key = ''
 ```
-## Generate Embeddings for the user Question
+
+## Generate embeddings for the user question
+
 We'll begin the retrieval process by generating embeddings for the user's question. 
 
 To do this, define a function that takes the user's question as input and converts it into an embedding. For this we'll be leveraging the  **Pre-built AI Models** in Microsoft Fabric. For this section we'll use the `text-embedding-ada-002` model to generate the embeddings.
@@ -491,7 +485,7 @@ def gen_question_embedding(user_question):
     return question_embedding
 ```
 
-Learn more about Pre-built AI Services in Microsoft Fabric [here](https://learn.microsoft.com/en-us/fabric/data-science/ai-services/ai-services-overview?WT.mc_id=data-114676-jndemenge)
+Learn more: [Pre-built AI Services in Microsoft Fabric](https://learn.microsoft.com/fabric/data-science/ai-services/ai-services-overview?WT.mc_id=data-114676-jndemenge)
 
 <div class="warning" data-title="Note">
 
@@ -510,7 +504,7 @@ To provide a response to the user's question, we'll need to retrieve the top K d
 import json 
 import requests
 
-def retrieve_k_chunk(k, question_embedding):
+def retrieve_top_chunks(k, question_embedding):
     # Retrieve the top K entries
     url = f"https://{aisearch_name}.search.windows.net/indexes/{aisearch_index_name}/docs/search?api-version=2023-07-01-Preview"
 
@@ -524,7 +518,6 @@ def retrieve_k_chunk(k, question_embedding):
 
     response = requests.request("POST", url, headers=headers, data=payload)
     output = json.loads(response.text)
-    print(response.status_code)
     return output
 ```
 Now that we have the top K document chunks, we can concatenate the content of the retrieved documents to form the context for the user's question. 
@@ -535,17 +528,20 @@ def get_context(user_question, retrieved_k = 5):
     question_embedding = gen_question_embedding(user_question)
 
     # Retrieve the top K entries
-    output = retrieve_k_chunk(retrieved_k, question_embedding)
+    output = retrieve_top_chunks(retrieved_k, question_embedding)
 
     # concatenate the content of the retrieved documents
-    context = [i["content"] for i in output["value"]]
+    context = [chunk["content"] for chunk in output["value"]]
 
     return context
 ```
+
 ## Answering the User's Question
+
 Finally we'll use the context generated from the retrieved documents to answer the user's question. To do this we'll use the pre-built AI Model in Microsoft Fabric. For this demo, we'll use the `gpt-35-turbo-16k`. This model is optimized for conversation.
 
 Begin by bring in the necessary libraries and then define a function to create a message.
+
 ```python
 from pyspark.sql import Row
 from pyspark.sql.types import *
@@ -556,9 +552,9 @@ def make_message(role, content):
     return Row(role=role, content=content, name=role)
 ```
 
-The function above creates a message with the role and content. The role can be either `user` or `system`.
+The function above creates a message with the role and content. The role can be either `system`, `user`, or `assistant`.
 
-Next, we will define another function that gets the response from the model, based on  the context and the user's question.
+Next, we will define another function that gets the response from the model, based on the context and the user's question.
 
 ```python
 def get_response(user_question):
@@ -605,7 +601,7 @@ def get_response(user_question):
     return result
 ```
 
-This function, first gets a context for the user's question, which is basically a list of documents that are relevant to the user's question. It then uses the context to create a prompt and then uses the prompt to get a response from the model.
+This function first gets a context for the user's question, which is basically a list of document chunks that are relevant to the user's question. It then uses the context to create a prompt and then uses the prompt to get a response from the model.
 
 <div class="warning" data-title="Note">
 
@@ -617,7 +613,7 @@ This function, first gets a context for the user's question, which is basically 
 ```
 </div>
 
-We can then use the function to get a response to the user's question.
+Finally, we can call that function to get a response to a user's question:
 
 ```python
 user_question = "how do i make a booking?"
@@ -643,7 +639,6 @@ This concludes this workshop, we hope you enjoyed it and learned something new.
 
 ## Clean up resources
 
-
 <div class="important" data-title="Important">
 
 > After completing the workshop, remember to delete the Azure Resources you created to avoid incurring unnecessary costs!
@@ -653,15 +648,17 @@ To delete the resources, navigate to the resource group you created earlier and 
 
 
 ## Resources
+
 To learn more about Retrieval Augmented Generation (RAG) using Azure Search an Azure OpenAI, refer to the following resources:
 
-- [Retrieval Augmented Generation (RAG) in Azure AI Search](https://learn.microsoft.com/en-us/azure/search/retrieval-augmented-generation-overview?WT.mc_id=data-114676-jndemenge)
-- [Use Azure OpenAI in Fabric with Python SDK and Synapse ML (preview)](https://learn.microsoft.com/en-gb/fabric/data-science/ai-services/how-to-use-openai-sdk-synapse?WT.mc_id=data-114676-jndemenge)
+- [Retrieval Augmented Generation (RAG) in Azure AI Search](https://learn.microsoft.com/azure/search/retrieval-augmented-generation-overview?WT.mc_id=data-114676-jndemenge)
+- [Use Azure OpenAI in Fabric with Python SDK and Synapse ML (preview)](https://learn.microsoft.com/fabric/data-science/ai-services/how-to-use-openai-sdk-synapse?WT.mc_id=data-114676-jndemenge)
 - [Azure OpenAI for big data](https://microsoft.github.io/SynapseML/docs/Explore%20Algorithms/OpenAI/)
 
-***Bonus:*** For more information on creating RAG applications with Microsoft Fabric’s Lakehouse Data and prompt flow in Azure Machine Learning Service, refer to this [resource](https://blog.fabric.microsoft.com/en-us/blog/using-microsoft-fabrics-lakehouse-data-and-prompt-flow-in-azure-machine-learning-service-to-create-rag-applications).
+***Bonus:*** For more information on creating RAG applications with Microsoft Fabric, refer to this blog post: [Using Microsoft Fabric’s Lakehouse Data and prompt flow in Azure Machine Learning Service to create RAG applications](https://blog.fabric.microsoft.com/en-us/blog/using-microsoft-fabrics-lakehouse-data-and-prompt-flow-in-azure-machine-learning-service-to-create-rag-applications).
 
 ## References
+
 - This workshop URL: [aka.ms/ws/fabric-rag](https://aka.ms/ws/fabric-rag)
 - If something does not work: [Report an issue](https://github.com/Azure-Samples/azure-openai-rag-workshop/issues)
 - Live Workshop on [YouTube](https://www.youtube.com/watch?v=BfNiaaBOcM8)

--- a/workshops/fabric-e2e-rag/workshop.md
+++ b/workshops/fabric-e2e-rag/workshop.md
@@ -607,9 +607,8 @@ Finally, we can define a function that takes a user's question, retrieves the co
 
 ```python
 from pyspark.sql import Row
-from pyspark.sql.types import *
-import synapse.ml.core
-from synapse.ml.services.openai import *
+from synapse.ml.services.openai import OpenAIChatCompletion
+
 
 def make_message(role, content):
     return Row(role=role, content=content, name=role)

--- a/workshops/fabric-e2e-rag/workshop.md
+++ b/workshops/fabric-e2e-rag/workshop.md
@@ -309,7 +309,7 @@ This integration enables the SynapseML embedding client to generate embeddings i
 
 For more detailed information on generating embeddings with Azure OpenAI, see: [Learn how to generate embeddings with Azure OpenAI](https://learn.microsoft.com/azure/cognitive-services/openai/how-to/embeddings?tabs=console&WT.mc_id=data-114676-jndemenge).
 
-<div class="info" data-title="Note">
+<div class="warning" data-title="Note">
 
 > If you're using the Azure OpenAI resource deployed on Microsoft Azure, you will need to provide the key as well as the deployment name for the Azure OpenAI resource, using `setDeploymentName` and `setSubscriptionKey`:
 >

--- a/workshops/fabric-e2e-rag/workshop.md
+++ b/workshops/fabric-e2e-rag/workshop.md
@@ -78,13 +78,6 @@ To get an in-depth understanding of the RAG framework, refer to [this workshop](
 
 To continue with this workshop, you'll need to create a Lakehouse in your Microsoft Fabric workspace and deploy the necessary resources in your Azure account. We'll detail the steps to do this below.
 
-## Create a Lakehouse
-
-To create a new Lakehouse in your Microsoft Fabric workspace, open the `New` dropdown and select `Lakehouse` from the options. Provide a name of `rag_workshop` and select `Create`.
-
-![Screenshot of New Lakehouse dialog in Synapse Data Engineering tab](assets/lakehouse.png)
-
-To learn more about Lakehouses in Microsoft Fabric, refer to [this Lakehouse tutorial](https://learn.microsoft.com/fabric/data-engineering/tutorial-build-lakehouse#create-a-lakehouse?WT.mc_id=data-114676-jndemenge).
 
 ## Azure Setup
 
@@ -129,6 +122,15 @@ Next you'll need to create new model deployments. To do this navigate to the [Az
 > You will have to provide the keys and deployment names for the Azure OpenAI resource in sections that are using the Azure OpenAI models.
 
 </div>
+
+## Create a Lakehouse
+
+To create a new Lakehouse in your Microsoft Fabric workspace, open the `New` dropdown and select `Lakehouse` from the options. Provide a name of `rag_workshop` and select `Create`.
+
+![Screenshot of New Lakehouse dialog in Synapse Data Engineering tab](assets/lakehouse.png)
+
+To learn more about Lakehouses in Microsoft Fabric, refer to [this Lakehouse tutorial](https://learn.microsoft.com/fabric/data-engineering/tutorial-build-lakehouse#create-a-lakehouse?WT.mc_id=data-114676-jndemenge).
+
 
 ---
 

--- a/workshops/fabric-e2e-rag/workshop.md
+++ b/workshops/fabric-e2e-rag/workshop.md
@@ -29,7 +29,7 @@ wt_id: data-114676-jndemenge
 
 In this workshop, we'll demonstrate how to develop a context-aware question answering framework for any form of a document using [OpenAI models](https://azure.microsoft.com/products/ai-services/openai-service), [SynapseML](https://microsoft.github.io/SynapseML/) and [Azure AI Services](https://azure.microsoft.com/products/cognitive-services/). The source of data for this workshop is a PDF document, however, the same framework can be easily extended to other document formats too.
 
-## You'll learn how to: 
+## You'll learn how to
 
 - Pre-Process PDF Documents using [Azure AI Document Intelligence](https://azure.microsoft.com/products/ai-services/ai-document-intelligence) in Azure AI Services.
 - Perform text chunking using SynapseML.
@@ -37,9 +37,7 @@ In this workshop, we'll demonstrate how to develop a context-aware question answ
 - Store the embeddings in a vector store using [Azure AI Search](https://azure.microsoft.com/products/search).
 - Build a question answering pipeline.
 
-
 ## Pre-requisites
-
 
 | | |
 |----------------------|------------------------------------------------------|
@@ -50,22 +48,18 @@ In this workshop, we'll demonstrate how to develop a context-aware question answ
 | A Web browser        | [Get Microsoft Edge](https://www.microsoft.com/edge) |
 | Python knowledge | [Python for beginners](https://learn.microsoft.com/training/paths/beginner-python/) |
 
-
-<div class="warning" data-title="Note">
-
+> [!WARNING]  
 > Since we are using the Pre-Built Open AI Models in Microsoft Fabric you do not need to request or have access to the Azure OpenAI API. However, if you are using the trial version of Microsoft Fabric or do not have an F64+ capacity, you will need to request access to the Azure OpenAI API.
-</div>
 
 ---
 
-
-# Introduction
+## Introduction
 
 Analyzing structured data has been an easy process for some time but the same cannot be said for unstructured data. Unstructured data, such as text, images, and videos, is more difficult to analyze and interpret. However, with the advent of advanced AI models, such as OpenAI's GPT-3 and GPT-4, it is now becoming easier to analyze and gain insights from unstructured data.
 
 An example of such analysis is the ability to query a document for specific information using natural language which is achievable though a combination of information retrieval and language generation.
 
-By leveraging the RAG (Retrieval-Augmented Generation) framework, you can create a powerful question-and-answering pipeline that uses a large language model (LLM) and you own data to generate responses. 
+By leveraging the RAG (Retrieval-Augmented Generation) framework, you can create a powerful question-and-answering pipeline that uses a large language model (LLM) and you own data to generate responses.
 
 The architecture of such an application is as shown below:
 
@@ -73,69 +67,63 @@ The architecture of such an application is as shown below:
 
 To get an in-depth understanding of the RAG framework, refer to [this workshop](https://moaw.dev/workshop/gh:azure-samples/azure-openai-rag-workshop/base/docs/)
 
-
 ---
 
-# Environment Setup
+## Environment Setup
+
 To continue with this workshop, you'll need to create a Lakehouse in your Microsoft Fabric workspace and deploy the necessary resources in your Azure account. We'll detail the steps to do this below.
 
-## Create a Lakehouse
+### Create a Lakehouse
+
 To create a new Lakehouse in your Microsoft Fabric workspace, open the `Data Engineering workload` on the bottom left of the workspace and click on `Lakehouse`. Provide the name `rag_workshop` and click `Create`
 
 ![Screenshot of New Lakehouse dialog in Synapse Data Engineering tab](assets/lakehouse.png)
 
 To learn more about Lakehouses in Microsoft Fabric, refer to [this resource](https://learn.microsoft.com/fabric/data-engineering/tutorial-build-lakehouse#create-a-lakehouse?WT.mc_id=data-114676-jndemenge)
 
+### Azure Setup
 
-## Azure Setup
+To complete this workshop you'll need an Azure account. If you don't have one, you can create a [free account](https://azure.microsoft.com/free/?WT.mc_id=data-0000-cxa) before you begin.
 
-To complete this workshop you'll need an Azure account. If you don't have one, you can create a [free account](https://azure.microsoft.com/free/?WT.mc_id=data-0000-cxa) before you begin. 
-
-<div class="important" data-title="Important">
-
+> [!IMPORTANT]
 > Ensure that the subscription you are using has the permissions to create and manage resources.
-</div>
-
 
 Navigate to the [Azure Portal](https://portal.azure.com) and click on `Create a resource` and search for `Azure AI Search`. Click on the `Azure AI Search` resource and then click on `Create`.
 
-![aisearch](assets/aisearch.png)
-
+![Screenshot of Azure AI Search creation wizard in Azure Portal](assets/aisearch.png)
 
 Fill out all the required fields and click `Review + Create` and once the validation is successful, click `Create`.
 
 Similarly, create another resource for the `Azure AI Services` by clicking on `Create a resource` and searching for `Azure AI Services`. Click on the `Azure AI Services` resource and then click on `Create`.
 
-![aiservice](assets/aiservice.png)
+![Screenshot of Azure AI Services creation wizard in Azure Portal](assets/aiservice.png)
 
 Fill out all the required fields, accept the Responsible AI Notice and then click `Review + Create` and once the validation is successful, click `Create`. Ensure that you select the same ***Resource Group*** as the ***Azure AI Search resource***.
 
-## Azure OpenAI Set Up
+### Azure OpenAI Set Up
 
-If your Microsoft Fabric SKU of F64 or higher, you can skip this step. 
+If your Microsoft Fabric SKU of F64 or higher, you can skip this step.
 
 However, if you using the trial version of Microsoft Fabric or it does not have an F64+ SKU, you will need to request access to the Azure OpenAI API from [here](https://aka.ms/oaiapply). Once you have access to the Azure OpenAI API, you'll need to create the Azure OpenAI resource in the Azure Portal.
 
-To do this navigate to the [Azure Portal] and click on `Create a resource` and search for `Azure OpenAI`. Click on the `Azure OpenAI` resource and then click on `Create`. 
+To do this navigate to the [Azure Portal] and click on `Create a resource` and search for `Azure OpenAI`. Click on the `Azure OpenAI` resource and then click on `Create`.
 
-![openai](assets/openai.png)
+![Screenshot of Azure OpenAI creation wizard in Azure Portal](assets/openai.png)
 
 Fill out all the required fields and click `Review + Create` and once the validation is successful, click `Create`. Also ensure that you select the same ***Resource Group*** as the ***Azure AI Search resource*** and the ***Azure AI Services resource***.
 
 Next you'll need to create new model deployments. To do this navigate to the [Azure OpenAI Studio](https://oai.azure.com/portal). Under management click on `Deployments` and then click on `Create Deployment`. You'll need to create two deployments, one for the `text-embedding-ada-002` model and another for the `gpt-35-turbo-16k` model.
 
-![deployments](assets/deployments.png)
+![Screenshot of "Deploy model" dialog in Azure OpenAI Studio](assets/deployments.png)
 
-<div class="warning" data-title="Note">
-
+> [!IMPORTANT]  
 > You will have to provide the keys and deployment names for the Azure OpenAI resource in sections that are using the Azure OpenAI models.
-</div>
 
 ---
 
-# Loading and Preprocessing PDF Documents 
+## Loading and Preprocessing PDF Documents
 
-Now that we have all the necessary resources deployed, we can begin building the RAG application. This section covers the process of loading and preprocessing PDF documents using Document Intelligence in Azure AI Services. 
+Now that we have all the necessary resources deployed, we can begin building the RAG application. This section covers the process of loading and preprocessing PDF documents using Document Intelligence in Azure AI Services.
 
 To do this, we'll perform the following steps:
 
@@ -144,14 +132,13 @@ To do this, we'll perform the following steps:
 - Extract the text from the PDF documents.
 - Use SynapseML to split the documents into chunks for more granular representation and processing of the document content.
 
-## Configure Azure API keys
+### Configure Azure API keys
 
-To begin, navigate back to your workspace and create a new notebook by selecting ```Open Notebook``` from the top menu and selecting ```New Notebook``` from the dropdown. 
+To begin, navigate back to your workspace and create a new notebook by selecting ```Open Notebook``` from the top menu and selecting ```New Notebook``` from the dropdown.
 
 This will open a new Notebook. On the top right corner of the workspace, select the `Save as` icon and rename it to ```analyze_and_create_embeddings```.
 
 Next you'll need to provide the keys for Azure AI Services to access the services. Copy the values from the Azure Portal and paste them into the following code cell.
-
 
 ```python
 # Azure AI Search
@@ -164,14 +151,11 @@ ai_services_key = ''
 ai_services_location = ''
 ```
 
-<div class="tip" data-title="Tip">
-
-> In a production scenario, it is recommended to store the credentials securely in Azure Key Vault. To access the credentials stored in Azure Key Vault, use the `mssparkutils` library. 
-
-</div>
+> [!TIP]
+> In a production scenario, it is recommended to store the credentials securely in Azure Key Vault. To access the credentials stored in Azure Key Vault, use the `mssparkutils` library.
 
 
-## Loading & Analyzing the Document
+### Loading & Analyzing the Document
 
 In this workshop, we will be using a specific document named [support.pdf](https://github.com/Azure-Samples/azure-openai-rag-workshop/blob/main/data/support.pdf) which will be the source of our data.
 
@@ -217,7 +201,7 @@ df = (
 
 This code will read the PDF document and create a Spark DataFrame named `df` with the contents of the PDFs. The DataFrame will have a schema that represents the structure of the PDF document, including its textual content.
 
-Next, we'll use the Azure AI Document Intelligence to read the PDF documents and extract the text from them. 
+Next, we'll use the Azure AI Document Intelligence to read the PDF documents and extract the text from them.
 
 We utilize [SynapseML](https://microsoft.github.io/SynapseML/), an ecosystem of tools designed to enhance the distributed computing framework [Apache Spark](https://github.com/apache/spark). SynapseML introduces advanced networking capabilities to the Spark ecosystem and offers user-friendly SparkML transformers for various [Azure AI Services](https://azure.microsoft.com/products/ai-services).
 
@@ -252,15 +236,15 @@ display(analyzed_df)
 
 ---
 
-# Generating Embeddings and Storing them in a Vector Store
+## Generating Embeddings and Storing them in a Vector Store
 
 Now that we have the text content of the PDF documents, we can generate embeddings for the text using Azure OpenAI. Embeddings are vector representations of the text that can be used to compare the similarity between different pieces of text.
 
-![chunking-vector](assets/chunking-vector.svg)
+![Diagram of flow from entire PDF file to chunks to embeddings](assets/chunking-vector.svg)
 
-This process begins by splitting the text into chunks, then for each of the chunks we generate Embeddings using Azure OpenAI. These embeddings are then stored in a vector store. 
+This process begins by splitting the text into chunks, then for each of the chunks we generate Embeddings using Azure OpenAI. These embeddings are then stored in a vector store.
 
-## Text Chunking
+### Text Chunking
 
 Before we can generate the embeddings, we need to split the text into chunks. To do this we leverage SynapseML’s PageSplitter to divide the documents into smaller sections, which are subsequently stored in the `chunks` column. This allows for more granular representation and processing of the document content.
 
@@ -279,7 +263,7 @@ splitted_df = ps.transform(analyzed_df)
 display(splitted_df)
 ```
 
-Note that the chunks for each document are presented in a single row inside an array. In order to embed all the chunks in the following cells, we need to have each chunk in a separate row. 
+Note that the chunks for each document are presented in a single row inside an array. In order to embed all the chunks in the following cells, we need to have each chunk in a separate row.
 
 ```python
 # Each column contains many chunks for the same document as a vector.
@@ -291,10 +275,12 @@ exploded_df = splitted_df.select("path", explode(col("chunks")).alias("chunk")).
 )
 display(exploded_df)
 ```
+
 From this code snippet we first explode these arrays so there is only one chunk in each row, then filter the Spark DataFrame in order to only keep the path to the document and the chunk in a single row.
 
-## Generating Embeddings
-Next we'll generate the embeddings for each chunk. To do this we utilize both SynapseML and Azure OpenAI Service. By integrating the built in Azure OpenAI service with SynapseML, we can leverage the power of the Apache Spark distributed computing framework to process numerous prompts using the OpenAI service. 
+### Generating Embeddings
+
+Next we'll generate the embeddings for each chunk. To do this we utilize both SynapseML and Azure OpenAI Service. By integrating the built in Azure OpenAI service with SynapseML, we can leverage the power of the Apache Spark distributed computing framework to process numerous prompts using the OpenAI service.
 
 ```python
 from synapse.ml.services import OpenAIEmbedding
@@ -312,12 +298,11 @@ df_embeddings = embedding.transform(exploded_df)
 display(df_embeddings)
 ```
 
-This integration enables the SynapseML embedding client to generate embeddings in a distributed manner, enabling efficient processing of large volumes of data. If you're interested in applying large language models at a distributed scale using Azure OpenAI and Azure Synapse Analytics, you can refer to [this approach](https://microsoft.github.io/SynapseML/docs/Explore%20Algorithms/OpenAI/). 
+This integration enables the SynapseML embedding client to generate embeddings in a distributed manner, enabling efficient processing of large volumes of data. If you're interested in applying large language models at a distributed scale using Azure OpenAI and Azure Synapse Analytics, you can refer to [this approach](https://microsoft.github.io/SynapseML/docs/Explore%20Algorithms/OpenAI/).
 
 For more detailed information on generating embeddings with Azure OpenAI, you can look [here](https://learn.microsoft.com/azure/cognitive-services/openai/how-to/embeddings?tabs=console&WT.mc_id=data-114676-jndemenge).
 
-
-## Storing Embeddings in a Vector Store
+### Storing Embeddings in a Vector Store
 
 [Azure AI Search](https://learn.microsoft.com/azure/search/search-what-is-azure-search?WT.mc_id=data-114676-jndemenge) offers a user-friendly interface for creating a vector database, as well as storing and retrieving data using vector search. If you're interested in learning more about vector search, you can look [here](https://github.com/Azure/cognitive-search-vector-pr/tree/main).
 
@@ -441,11 +426,11 @@ display(df_embeddings)
 
 ---
 
-# Retrieving Relevant Documents and Answering Questions
+## Retrieving Relevant Documents and Answering Questions
 
-After processing the document, we can proceed to pose a question. We will use [SynapseML](https://microsoft.github.io/SynapseML/docs/Explore%20Algorithms/OpenAI/Quickstart%20-%20OpenAI%20Embedding/) to convert the user's question into an embedding and then utilize cosine similarity to retrieve the top K document chunks that closely match the user's question. 
+After processing the document, we can proceed to pose a question. We will use [SynapseML](https://microsoft.github.io/SynapseML/docs/Explore%20Algorithms/OpenAI/Quickstart%20-%20OpenAI%20Embedding/) to convert the user's question into an embedding and then utilize cosine similarity to retrieve the top K document chunks that closely match the user's question.
 
-## Configure Environment & Azure API Keys
+### Configure Environment & Azure API Keys
 
 Create a new notebook in the Lakehouse and save it as `rag_application`. We'll use this notebook to build the RAG application.
 
@@ -458,12 +443,11 @@ aisearch_index_name = 'rag-demo-index'
 aisearch_api_key = ''
 ```
 
-## Generate embeddings for the user question
+### Generate embeddings for the user question
 
-We'll begin the retrieval process by generating embeddings for the user's question. 
+We'll begin the retrieval process by generating embeddings for the user's question.
 
 To do this, define a function that takes the user's question as input and converts it into an embedding. For this we'll be leveraging the  **Pre-built AI Models** in Microsoft Fabric. For this section we'll use the `text-embedding-ada-002` model to generate the embeddings.
-
 
 ```python
 # Ask a question and convert to embeddings
@@ -495,9 +479,11 @@ Learn more: [Pre-built AI Services in Microsoft Fabric](https://learn.microsoft.
     .setDeploymentName('text-embedding-ada-002')
     .setSubscriptionKey(azure_openai_key)
 ```
+
 </div>
 
-## Retrieve Relevant Documents	
+### Retrieve Relevant Documents
+
 To provide a response to the user's question, we'll need to retrieve the top K document chunks that closely match the user's question from the vector database. To retrieve the top K document chunks, we'll use the following function.
 
 ```python
@@ -520,7 +506,8 @@ def retrieve_top_chunks(k, question_embedding):
     output = json.loads(response.text)
     return output
 ```
-Now that we have the top K document chunks, we can concatenate the content of the retrieved documents to form the context for the user's question. 
+
+Now that we have the top K document chunks, we can concatenate the content of the retrieved documents to form the context for the user's question.
 
 ```python
 def get_context(user_question, retrieved_k = 5):
@@ -536,7 +523,7 @@ def get_context(user_question, retrieved_k = 5):
     return context
 ```
 
-## Answering the User's Question
+### Answering the User's Question
 
 Finally we'll use the context generated from the retrieved documents to answer the user's question. To do this we'll use the pre-built AI Model in Microsoft Fabric. For this demo, we'll use the `gpt-35-turbo-16k`. This model is optimized for conversation.
 
@@ -603,14 +590,14 @@ def get_response(user_question):
 
 This function first gets a context for the user's question, which is basically a list of document chunks that are relevant to the user's question. It then uses the context to create a prompt and then uses the prompt to get a response from the model.
 
-<div class="warning" data-title="Note">
-
+> [!WARNING]  
 > If you are using the Azure OpenAI resource deployed on Microsoft Azure you will need to provide the Key as well as the Deployment Name for the Azure OpenAI resource. To do this replace the `deploymentName` with the name of the deployment you created in the Azure OpenAI Studio and add the key as follows:
+>
+> ```python
+>   .setDeploymentName('gpt-35-turbo-16k')
+>   .setSubscriptionKey(azure_openai_key)
+> ```
 
-```python
-    .setDeploymentName('gpt-35-turbo-16k')
-    .setSubscriptionKey(azure_openai_key)
-```
 </div>
 
 Finally, we can call that function to get a response to a user's question:
@@ -623,31 +610,24 @@ print(response)
 
 This gives a result similar to the following:
 
-![response](assets/response.png)
-
+![Screenshot of notebook showing LLM response about making a booking](assets/response.png)
 
 ---
 
-# Conclusion
+## Conclusion
 
-This concludes this workshop, we hope you enjoyed it and learned something new. 
+This concludes this workshop, we hope you enjoyed it and learned something new.
 
-<div class="warning" data-title="Had Issues?">
+If you had any issues while following this workshop, please let us know by [creating a new issue](https://github.com/microsoft/moaw/issues) on the github repository.
 
-> If you had any issues while following this workshop, please let us know by [creating a new issue](https://github.com/microsoft/moaw/issues) on the github repository.
-</div>
+### Clean up resources
 
-## Clean up resources
-
-<div class="important" data-title="Important">
-
+> [!IMPORTANT]  
 > After completing the workshop, remember to delete the Azure Resources you created to avoid incurring unnecessary costs!
-</div>
 
 To delete the resources, navigate to the resource group you created earlier and click on the `Delete` button.
 
-
-## Resources
+### Resources
 
 To learn more about Retrieval Augmented Generation (RAG) using Azure Search an Azure OpenAI, refer to the following resources:
 
@@ -657,7 +637,7 @@ To learn more about Retrieval Augmented Generation (RAG) using Azure Search an A
 
 ***Bonus:*** For more information on creating RAG applications with Microsoft Fabric, refer to this blog post: [Using Microsoft Fabric’s Lakehouse Data and prompt flow in Azure Machine Learning Service to create RAG applications](https://blog.fabric.microsoft.com/en-us/blog/using-microsoft-fabrics-lakehouse-data-and-prompt-flow-in-azure-machine-learning-service-to-create-rag-applications).
 
-## References
+### References
 
 - This workshop URL: [aka.ms/ws/fabric-rag](https://aka.ms/ws/fabric-rag)
 - If something does not work: [Report an issue](https://github.com/Azure-Samples/azure-openai-rag-workshop/issues)

--- a/workshops/fabric-e2e-rag/workshop.md
+++ b/workshops/fabric-e2e-rag/workshop.md
@@ -80,11 +80,11 @@ To continue with this workshop, you'll need to create a Lakehouse in your Micros
 
 ## Create a Lakehouse
 
-To create a new Lakehouse in your Microsoft Fabric workspace, open the `Data Engineering workload` on the bottom left of the workspace and click on `Lakehouse`. Provide the name `rag_workshop` and click `Create`
+To create a new Lakehouse in your Microsoft Fabric workspace, open the `New` dropdown and select `Lakehouse` from the options. Provide a name of `rag_workshop` and select `Create`.
 
 ![Screenshot of New Lakehouse dialog in Synapse Data Engineering tab](assets/lakehouse.png)
 
-To learn more about Lakehouses in Microsoft Fabric, refer to [this resource](https://learn.microsoft.com/fabric/data-engineering/tutorial-build-lakehouse#create-a-lakehouse?WT.mc_id=data-114676-jndemenge)
+To learn more about Lakehouses in Microsoft Fabric, refer to [this Lakehouse tutorial](https://learn.microsoft.com/fabric/data-engineering/tutorial-build-lakehouse#create-a-lakehouse?WT.mc_id=data-114676-jndemenge).
 
 ## Azure Setup
 
@@ -100,19 +100,19 @@ Navigate to the [Azure Portal](https://portal.azure.com) and click on `Create a 
 
 ![Screenshot of Azure AI Search creation wizard in Azure Portal](assets/aisearch.png)
 
-Fill out all the required fields and click `Review + Create` and once the validation is successful, click `Create`.
+In the creation wizard, create a new resource group or select an existing one. To minimize costs, change the pricing tier from Standard to Free. Click `Review + Create` and once the validation is successful, click `Create`.
 
 Similarly, create another resource for the `Azure AI Services` by clicking on `Create a resource` and searching for `Azure AI Services`. Click on the `Azure AI Services` resource and then click on `Create`.
 
 ![Screenshot of Azure AI Services creation wizard in Azure Portal](assets/aiservice.png)
 
-Fill out all the required fields, accept the Responsible AI Notice and then click `Review + Create` and once the validation is successful, click `Create`. Ensure that you select the same ***Resource Group*** as the ***Azure AI Search resource***.
+In the creation wizard, select the same resource group that you used for the Azure AI Search resource. The only available pricing tier is Standard, but you can apply free credits if you have any. Accept the Responsible AI Notice. With all fields filled out, click `Review + Create`. Once the validation is successful, click `Create`.
 
 ## Azure OpenAI Set Up
 
-If your Microsoft Fabric SKU of F64 or higher, you can skip this step.
+If your Microsoft Fabric has a SKU of F64 or higher, you can skip this step.
 
-However, if you using the trial version of Microsoft Fabric or it does not have an F64+ SKU, you will need to request access to the Azure OpenAI API from [here](https://aka.ms/oaiapply). Once you have access to the Azure OpenAI API, you'll need to create the Azure OpenAI resource in the Azure Portal.
+However, if you're using the trial version of Microsoft Fabric or it does not have an F64+ SKU, you will need to request access to the Azure OpenAI API  [using this form](https://aka.ms/oaiapply). Once you have access to the Azure OpenAI API, you'll need to create the Azure OpenAI resource in the Azure Portal.
 
 To do this navigate to the [Azure Portal] and click on `Create a resource` and search for `Azure OpenAI`. Click on the `Azure OpenAI` resource and then click on `Create`.
 
@@ -145,9 +145,9 @@ To do this, we'll perform the following steps:
 
 ## Configure Azure API keys
 
-To begin, navigate back to your workspace and create a new notebook by selecting ```Open Notebook``` from the top menu and selecting ```New Notebook``` from the dropdown.
+To begin, navigate back to the `rag_workshop` lakehouse in your workspace and create a new notebook by selecting `Open Notebook` from the top menu and selecting `New Notebook` from the dropdown.
 
-This will open a new Notebook. On the top right corner of the workspace, select the `Save as` icon and rename it to ```analyze_and_create_embeddings```.
+This will open a new notebook. Select the `Save as` icon and rename the notebook to `analyze_and_create_embeddings`.
 
 Next you'll need to provide the keys for Azure AI Services to access the services. Copy the values from the Azure Portal and paste them into the following code cell.
 
@@ -173,7 +173,7 @@ ai_services_location = ''
 
 In this workshop, we will be using a specific document named [support.pdf](https://github.com/Azure-Samples/azure-openai-rag-workshop/blob/main/data/support.pdf) which will be the source of our data.
 
-To download the document paste the following code in a new cell and run it.
+To download the document, paste the following code in a new cell and run it.
 
 ```python
 import requests


### PR DESCRIPTION
This PR includes a number of changes based on my testing of the workshop and a meeting with search engineer @mattgotteiner. Usually I'd like to split changes into multiple PRs but given the workshop is coming up soon, it's all in this PR.

High level:

* Ran markdown lint over files, made auto-fixes and accessibility improvements to alt text.
* Updated Azure AI search code to latest SDK as the one referenced now is nearing deprecation. I wanted to also use the Python SDK, but that requires customizing the Spark environment which takes ~20 minutes, which isn't great for a live demo. I do have the SDK code equivalent if we're interested in that.
* Changed wording of Azure AI search from "vector database" to "search engine" and changed the vector search to hybrid search, since that's best practice.
* Changed the UDF to a mapPartitions call with batches of 1000. It's not a great practice to use a UDF to make a single API call, especially when that API supports batch operations. From my discussion with Spark developers, UDFs are better for compute-heavy operations.

Still TODO:

* Figure out if the synapse call is compatible with OpenAI proxy.
* Consider storage in Key Vault. (Probably out of scope for workshop, but another best practice)