### PR TITLE
feat: Add external workshop Platform engineering for devs

### DIFF
--- a/packages/database/external.yml
+++ b/packages/database/external.yml
@@ -438,3 +438,25 @@
   level: beginner
   tags: azure, dev center, azure deployment environment, microsoft dev box, azure policies, github, ghas, ops, csu
   navigation_levels: 3
+
+  
+- title: Product Hands-on Lab - Platform engineering for Devs
+  url: https://microsoft.github.io/moaw/workshop/gh:ikhemissi/hands-on-lab-platform-engineering-for-devs/main/docs/
+  github_url: https://github.com/ikhemissi/hands-on-lab-platform-engineering-for-devs
+  language: en
+  last_updated: 2024-06-20
+  type: workshop
+  description:  This workshop will guide you on how to fast start your dev experience, how to deploy to Azure, and how to detect potential issues with your code during run time.
+  authors:
+    - Iheb Khemissi
+    - François-Xavier Kim
+    - Louis-Guillaume Morand
+  contacts:
+    - "@ikhemissi"
+    - "@frkim"
+    - "@lomorand"
+  duration_minutes: 180
+  audience: pro devs, architects
+  level: beginner
+  tags: azure, devbox, ade, deployment environment, azd, azure developer cli, azure functions, azure load testing, application insights, csu
+  navigation_levels: 3

--- a/packages/database/external.yml
+++ b/packages/database/external.yml
@@ -454,7 +454,7 @@
   contacts:
     - "@ikhemissi"
     - "@frkim"
-    - "@lomorand"
+    - "@lgmorand"
   duration_minutes: 180
   audience: pro devs, architects
   level: beginner


### PR DESCRIPTION
Add the external workshop "Platform engineering for devs Hands-on Lab" which guides attendees on how to fast start their dev experience, how to deploy to Azure, and how to detect potential issues with their code during run time.