### PR TITLE
Add workshop details for Microsoft Fabric event-driven architecture

### DIFF
--- a/packages/database/external.yml
+++ b/packages/database/external.yml
@@ -680,15 +680,15 @@
   language: en
   last_updated: 2026-03-06
   type: workshop
-  description:  In this technical workshop, you will build a complete analytics platform with streaming data using Microsoft Fabric Real-Time Intelligence components and other features of Microsoft Fabric. This is a proctor-led workshop in which each section is accompanied by a technical overview of Fabric RTI components.
+  description: In this technical workshop, you will build a complete analytics platform with streaming data using Microsoft Fabric Real-Time Intelligence components and other features of Microsoft Fabric. This is a proctor-led workshop in which each section is accompanied by a technical overview of Fabric RTI components.
   authors:
-  - Brian Bønk Rueløkke
-  - Devang Shah
-  - Frank Geisler
-  - Johan Ludvig Brattås
-  - Matt Gordon
-  - Minni Walia
-  - Heidi Hasting
+    - Brian Bønk Rueløkke
+    - Devang Shah
+    - Frank Geisler
+    - Johan Ludvig Brattås
+    - Matt Gordon
+    - Minni Walia
+    - Heidi Hasting
   contacts:
     - "@minwal"
   duration_minutes: 360

--- a/packages/database/external.yml
+++ b/packages/database/external.yml
@@ -680,7 +680,7 @@
   language: en
   last_updated: 2026-03-06
   type: workshop
-  description:  In this technical workshop, you will build a complete analytics platform with streaming data using Microsoft Fabric Real-Time Intelligence components and other features of Microsoft Fabric. This is a proctor led workshop in which each section is accompanied by a technical overview of Fabric RTI components.
+  description:  In this technical workshop, you will build a complete analytics platform with streaming data using Microsoft Fabric Real-Time Intelligence components and other features of Microsoft Fabric. This is a proctor-led workshop in which each section is accompanied by a technical overview of Fabric RTI components.
   authors:
   - Brian Bønk Rueløkke
   - Devang Shah

--- a/packages/database/external.yml
+++ b/packages/database/external.yml
@@ -674,7 +674,6 @@
   level: beginner
   tags: azure, managed redis, database, serverless, apim, cache, csu
 
-
 - title: Building Scalable Real-Time Solutions using Event-Driven Architectures with Microsoft Fabric
   url: https://microsoft.github.io/moaw/workshop/gh:minwal/FabConATLRTIWorkshop/main/docs/
   github_url: https://github.com/minwal/FabConATLRTIWorkshop

--- a/packages/database/external.yml
+++ b/packages/database/external.yml
@@ -673,3 +673,26 @@
   audience: students, pro devs
   level: beginner
   tags: azure, managed redis, database, serverless, apim, cache, csu
+
+
+- title: Building Scalable Real-Time Solutions using Event-Driven Architectures with Microsoft Fabric
+  url: https://microsoft.github.io/moaw/workshop/gh:minwal/FabConATLRTIWorkshop/main/docs/
+  github_url: https://github.com/minwal/FabConATLRTIWorkshop
+  language: en
+  last_updated: 2026-03-06
+  type: workshop
+  description:  In this technical workshop, you will build a complete analytics platform with streaming data using Microsoft Fabric Real-Time Intelligence components and other features of Microsoft Fabric. This is a proctor led workshop in which each section is accompanied by a technical overview of Fabric RTI components.
+  authors:
+  - Brian Bønk Rueløkke
+  - Devang Shah
+  - Frank Geisler
+  - Johan Ludvig Brattås
+  - Matt Gordon
+  - Minni Walia
+  - Heidi Hasting
+  contacts:
+    - "@minwal"
+  duration_minutes: 360
+  audience: students, pro devs, data engineers, data architects, analysts
+  level: intermediate
+  tags: fabric, kql, realtime, intelligence, event, stream, sql, data, analytics, kusto, medallion, dashboard, reflex, activator

--- a/packages/database/external.yml
+++ b/packages/database/external.yml
@@ -674,7 +674,7 @@
   level: beginner
   tags: azure, managed redis, database, serverless, apim, cache, csu
 
-- title: Building Scalable Real-Time Solutions using Event-Driven Architectures with Microsoft Fabric
+- title: Microsoft Fabric Building Scalable Real-Time Solutions using Event-Driven Architectures
   url: https://microsoft.github.io/moaw/workshop/gh:minwal/FabConATLRTIWorkshop/main/docs/
   github_url: https://github.com/minwal/FabConATLRTIWorkshop
   language: en


### PR DESCRIPTION
Add workshop on Event-Driven Architectures with Microsoft Fabric Added a new workshop entry for building scalable real-time solutions using Microsoft Fabric, including details such as title, URL, authors, and description.

This is workshop for Fabcon Atlanta 2026