### PR TITLE
fix: restore dual-origin base href while keeping it parameterized

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,6 +35,7 @@ jobs:
       run: npm run build:website
       env:
         SEARCH_URL: ${{ secrets.SEARCH_URL }}
+        BASE_HREF: /moaw/
     - name: Setup GitHub Pages
       uses: actions/configure-pages@v4
     - name: Upload artifact

--- a/packages/website/scripts/update-env.sh
+++ b/packages/website/scripts/update-env.sh
@@ -16,8 +16,11 @@ fi
 dist_folder="dist/website"
 version="sha.$(git rev-parse --short HEAD)"
 ai_search_url="${AI_SEARCH_URL:-}"
+base_href="${BASE_HREF:-/moaw/}"
 
 perl -i -pe "s/__VERSION__/$version/g" $dist_folder/main.*.js
 perl -i -pe "s/__AI_SEARCH_URL__/$ai_search_url/g" $dist_folder/main.*.js
+perl -i -pe "s|__BASE_HREF__|$base_href|g" $dist_folder/index.html $dist_folder/404.html
 
 echo Version: $version
+echo Base href: $base_href

--- a/packages/website/src/public/404.html
+++ b/packages/website/src/public/404.html
@@ -4,7 +4,7 @@
   <!-- Workaround for GitHub Pages not supporting SPA routing -->
   <script>
     sessionStorage.redirect = location.href;
-    const url = window.location.hostname.includes('.github.io') ? '/moaw/' : '/';
+    const url = window.location.hostname.includes('.github.io') ? '__BASE_HREF__' : '/';
     window.location.replace(url);
   </script>
 </head>

--- a/packages/website/src/public/404.html
+++ b/packages/website/src/public/404.html
@@ -4,7 +4,9 @@
   <!-- Workaround for GitHub Pages not supporting SPA routing -->
   <script>
     sessionStorage.redirect = location.href;
-    const url = window.location.hostname.includes('.github.io') ? '__BASE_HREF__' : '/';
+    const hostname = window.location.hostname;
+    const isGitHubPagesHost = hostname === 'github.io' || hostname.endsWith('.github.io');
+    const url = isGitHubPagesHost ? '__BASE_HREF__' : '/';
     window.location.replace(url);
   </script>
 </head>

--- a/packages/website/src/public/index.html
+++ b/packages/website/src/public/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <script>
     if (window.location.hostname.includes('.github.io')) {
-      window.document.head.getElementsByTagName('base')[0].href = '/moaw/';
+      window.document.head.getElementsByTagName('base')[0].href = '__BASE_HREF__';
     }
   </script>
   <link rel="icon" type="image/png" href="favicon.png">


### PR DESCRIPTION
## Problem

The main deployment broke after #173 was merged, and that PR had to be reverted (#180). This restores the intent of #173 without breaking production.

The same single static build is served from **two origins**:
- `moaw.dev` → root path `/`
- `*.github.io/moaw/` → sub-path `/moaw/`

The original code handled this at **runtime** (detect `.github.io` hostname → use `/moaw/`, otherwise `/`). PR #173 replaced that with a **build-time** hardcoded `BASE_HREF=/moaw/`, so the one deployed artifact always used `/moaw/`. On `moaw.dev` (served at root) every asset/route then resolved to a non-existent `/moaw/...`, breaking the site.

## Fix

Keep the runtime `.github.io` detection (so both origins work) **and** keep PR #173's parameterization goal (hostable in other repos):

- `index.html` / `404.html`: the `.github.io` branch now uses a `__BASE_HREF__` token instead of a hardcoded `/moaw/`. The static `<base href="/">` is untouched, so root domains stay correct.
- `update-env.sh`: substitutes `__BASE_HREF__` in `index.html` + `404.html` with `${BASE_HREF:-/moaw/}`.
- `deploy.yml`: sets `BASE_HREF: /moaw/`.

A fork can now set `BASE_HREF` to its own sub-path, while `moaw.dev` (root) and `*.github.io/moaw/` both keep working from the same build.

## Verification

- `BASE_HREF=/moaw/ npm run build:website` succeeds.
- In `dist`, `__BASE_HREF__` substitutes to `/moaw/`, `<base href="/">` stays intact, and no leftover tokens remain.